### PR TITLE
FIX - Replace Yes/No with TwoOptions

### DIFF
--- a/powerapps-docs/developer/component-framework/manifest-schema-reference/includes/type-table.md
+++ b/powerapps-docs/developer/component-framework/manifest-schema-reference/includes/type-table.md
@@ -31,7 +31,7 @@ ms.assetid: 41ea27ac-65b6-45a4-ae03-5f8d02dfc67b
 |SingleLine.TextArea|This format option can be used to display multiple lines of text. But with a limit of 4000 characters, the Multiple Lines of Text column is a better choice if large amounts of text are expected.|
 |SingleLine.Ticker|For most languages, the text will be enabled as a link to open the MSN Money website to show details about the stock price represented by the ticker symbol.For certain East Asian languages the window will open Bing search results for the ticker symbol.|
 |SingleLine.URL|The text provides a hyperlink to open the page specified. Any text that does not begin with a valid protocol will have "https://" prepended to it.Only HTTP, HTTPS, FTP , FTPS, OneNote and TEL protocols are allowed in this column.|
-|Yes/No|This column provides two options. Each option has a number value of 0 or 1 corresponding to a false or true value. Each option also has a label so that true or false values can be represented as "Yes" and "No", "Hot" and "Cold", "On" and "Off" or any pair of labels you want to display.|
+|TwoOptions|This column provides two options. Each option has a number value of 0 or 1 corresponding to a false or true value. Each option also has a label so that true or false values can be represented as "Yes" and "No", "Hot" and "Cold", "On" and "Off" or any pair of labels you want to display.|
 |Whole.None|This option simply displays a number.|
 |Lookup.Simple|Allows for a single reference to a specific table. All custom lookups are this type.|
 


### PR DESCRIPTION
Typings file for manifest doesn't contain the property Yes/No. Instead, it has property TwoOptions